### PR TITLE
Dispose DotNet-BlueZ devices that are not being watched

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     building via build.ps1 or build.sh. It is defined here to allow Visual Studio to build with 
     the solution with the correct version number.
     -->
-    <Version>0.12.1</Version>
+    <Version>0.13.0</Version>
   </PropertyGroup>
 
   <Choose>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,6 @@
     <PackageVersion Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageVersion Include="System.Text.Json" Version="6.0.6" />
     <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
-    <PackageVersion Include="Tmds.DBus" Version="0.11.0" />
+    <PackageVersion Include="Tmds.DBus" Version="0.20.0" />
   </ItemGroup>
 </Project>

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 0,
-  "Minor": 12,
-  "Patch": 2,
+  "Minor": 13,
+  "Patch": 0,
   "PreRelease": ""
 }

--- a/src/NRuuviTag.Listener.Linux/NRuuviTag.Listener.Linux.csproj
+++ b/src/NRuuviTag.Listener.Linux/NRuuviTag.Listener.Linux.csproj
@@ -20,7 +20,7 @@
     <Content Include="..\submodules\DotNet-BlueZ\src\bin\$(Configuration)\$(TargetFramework)\DotNetBlueZ.dll">
       <Pack>true</Pack>
       <PackagePath>lib\$(TargetFramework)</PackagePath>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   

--- a/src/NRuuviTag.Listener.Linux/NRuuviTag.Listener.Linux.csproj
+++ b/src/NRuuviTag.Listener.Linux/NRuuviTag.Listener.Linux.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\submodules\DotNet-BlueZ\src\bin\$(Configuration)\netstandard2.0\DotNetBlueZ.dll">
+    <Content Include="..\submodules\DotNet-BlueZ\src\bin\$(Configuration)\$(TargetFramework)\DotNetBlueZ.dll">
       <Pack>true</Pack>
       <PackagePath>lib\$(TargetFramework)</PackagePath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
This PR modifies the Linux listener so that DotNet-BlueZ `Device` instances passed to a `BlueZListener` via DotNet-BlueZ's `Adapter.DeviceFound` event that are not added to the device watch list are disposed.

This is an attempt to mitigate the error seen in #4.