### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The repository contains a [core library](/src/NRuuviTag.Core) that defines commo
 The repository contains the following listener implementations:
 
 - [Windows](/src/NRuuviTag.Listener.Windows) (using the Windows 10 SDK)
-- [Linux](/src/NRuuviTag.Listener.Linux) (using [DotNet-BlueZ](https://github.com/hashtagchris/DotNet-BlueZ) to receive advertisements from BlueZ's D-Bus APIs)
+- [Linux](/src/NRuuviTag.Listener.Linux) (using a modified version of [DotNet-BlueZ](https://github.com/wazzamatazz/DotNet-BlueZ) to receive advertisements from BlueZ's D-Bus APIs)
 
 The `nruuvitag` [command-line tool](#command-line-application) can be used to as a turnkey solution to start receiving and publishing RuuviTag sensor data to an MQTT server or Azure Event Hub.
 
@@ -131,6 +131,11 @@ nruuvitag publish az "MY_CONNECTION_STRING" "MY_EVENT_HUB" --batch-size-limit 10
 # Linux Service
 
 The command-line application can be run as a Linux service using systemd. See [here](/docs/LinuxSystemdService.md) for details.
+
+
+# Linux Container Image
+
+The command-line application can be run as a Linux container image. See [here](/docs/Docker.md) for details. Note that the container runs as the `root` user to allow BlueZ to access the Bluetooth adapter.
 
 
 # Building the Solution

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -2,18 +2,18 @@
 
 ## Building the Container Image
 
-To build a Linux container image for the NRuuviTag CLI application, run the 'PublishContainers' target using the build script:
+To build a Linux container image for the NRuuviTag CLI application, run the 'PublishContainer' target using the build script:
 
 **PowerShell**
 
 ```pwsh
-.\build.ps1 --target PublishContainers --configuration Release
+.\build.ps1 --target PublishContainer --configuration Release
 ``` 
 
 **Bash**
 
 ```sh
-./build.sh --target PublishContainers --configuration Release
+./build.sh --target PublishContainer --configuration Release
 ``` 
 
 The default settings publish an x64 Linux image to the local Docker or Podman registry. To publish an image for a different architecture (e.g. `arm64`) specify the `--container-arch` parameter when running the build script. You can also publish the image to an alternative container registry by specifying the `--container-registry` parameter. For example:
@@ -22,7 +22,7 @@ The default settings publish an x64 Linux image to the local Docker or Podman re
 
 ```pwsh
 .\build.ps1 `
-    --target Publish `
+    --target PublishContainer `
     --configuration Release `
     --container-arch arm64 `
     --container-registry myregistry.mymachine.local:5000
@@ -32,7 +32,7 @@ The default settings publish an x64 Linux image to the local Docker or Podman re
 
 ```sh
 ./build.sh \
-    --target Publish \
+    --target PublishContainer \
     --configuration Release \
     --container-arch arm64 \
     --container-registry myregistry.mymachine.local:5000


### PR DESCRIPTION
This PR corrects some mistakes in the Docker instructions and adds information about running `nruuvitag` on Linux using Docker to the main README.md file.