### PR TITLE
Logging and cancellation cleanup

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
   "Minor": 0,
-  "Patch": 0,
+  "Patch": 1,
   "PreRelease": ""
 }

--- a/src/NRuuviTag.Cli/Commands/PublishAzureEventHubCommand.cs
+++ b/src/NRuuviTag.Cli/Commands/PublishAzureEventHubCommand.cs
@@ -76,8 +76,8 @@ namespace NRuuviTag.Cli.Commands {
         /// <inheritdoc/>
         public override async Task<int> ExecuteAsync(CommandContext context, PublishAzureEventHubCommandSettings settings) {
             if (!_appLifetime.ApplicationStarted.IsCancellationRequested) {
-                try { await Task.Delay(-1, _appLifetime.ApplicationStarted).ConfigureAwait(false); }
-                catch (OperationCanceledException) { }
+                try { await Task.Delay(Timeout.InfiniteTimeSpan, _appLifetime.ApplicationStarted).ConfigureAwait(false); }
+                catch (OperationCanceledException) when (_appLifetime.ApplicationStarted.IsCancellationRequested) { }
             }
 
             IEnumerable<Device> devices = Array.Empty<Device>();

--- a/src/NRuuviTag.Cli/Commands/PublishMqttCommand.cs
+++ b/src/NRuuviTag.Cli/Commands/PublishMqttCommand.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;

--- a/src/NRuuviTag.Mqtt.Agent/MqttAgent.cs
+++ b/src/NRuuviTag.Mqtt.Agent/MqttAgent.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -301,7 +300,13 @@ namespace NRuuviTag.Mqtt {
         ///   The event arguments.
         /// </param>
         private Task OnConnectedAsync(MqttClientConnectedEventArgs args) {
-            LogMqttClientConnected();
+            var hostname = _mqttClientOptions.ClientOptions.ChannelOptions switch {
+                MqttClientTcpOptions tcpOptions => tcpOptions.RemoteEndpoint.ToString(),
+                MqttClientWebSocketOptions wsOptions => wsOptions.Uri.ToString(),
+                _ => "<unknown>"
+            };
+            LogMqttClientConnected(hostname);
+            
             return Task.CompletedTask;
         }
 
@@ -611,8 +616,8 @@ namespace NRuuviTag.Mqtt {
         [LoggerMessage(2, LogLevel.Information, "Stopped MQTT agent.")]
         partial void LogMqttAgentStopped();
 
-        [LoggerMessage(3, LogLevel.Information, "Connected to MQTT broker.")]
-        partial void LogMqttClientConnected();
+        [LoggerMessage(3, LogLevel.Information, "Connected to MQTT broker: {hostname}")]
+        partial void LogMqttClientConnected(string hostname);
 
         [LoggerMessage(4, LogLevel.Warning, "Disconnected from MQTT broker.")]
         partial void LogMqttClientDisconnected(Exception error);


### PR DESCRIPTION
This PR includes the MQTT broker hostname in the log message when connecting to the MQTT broker, and modifies the Azure Event Hub publisher so that it only swallows cancellation exceptions caused by the application started cancellation token.