### PR TITLE
Update Cake tool and Jaahas.Cake.Extensions versions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/build.cake
+++ b/build.cake
@@ -73,7 +73,7 @@ const string VersionFile = "./build/version.json";
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=3.1.0
+#load nuget:?package=Jaahas.Cake.Extensions&version=4.0.1
 
 // Bootstrap build context and tasks.
 Bootstrap(


### PR DESCRIPTION
Bump Cake tool to version 5.0.0 in dotnet-tools.json and update Jaahas.Cake.Extensions to 4.0.1 in build.cake for compatibility and latest features.