### PR TITLE
Use Linux.Bluetooth for Linux listener

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/submodules/DotNet-BlueZ"]
-	path = src/submodules/DotNet-BlueZ
-	url = https://github.com/wazzamatazz/DotNet-BlueZ

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,11 @@ The project uses Cake build automation with cross-platform support:
 ./build.sh --target=PublishContainer
 ```
 
+## Package Management
+
+The project uses NuGet Central Package Management to manage dependencies. The `Directory.Packages.props` file defines common package versions used across the solution.
+
+
 ## Architecture
 
 ### Core Components

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,9 +13,10 @@
     <PackageVersion Include="Jaahas.CertificateUtilities" Version="1.2.0" />
     <PackageVersion Include="Jaahas.OpenTelemetry.Extensions" Version="3.0.0" />
     <PackageVersion Include="Jaahas.Spectre.Extensions.Hosting" Version="2.0.0" />
+    <PackageVersion Include="Linux.Bluetooth" Version="5.67.1" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.7" />

--- a/NRuuviTag.slnx
+++ b/NRuuviTag.slnx
@@ -34,11 +34,6 @@
     <Project Path="src/NRuuviTag.Mqtt.Agent/NRuuviTag.Mqtt.Agent.csproj" />
     <Project Path="src/NRuuviTag.OpenTelemetry/NRuuviTag.OpenTelemetry.csproj" />
   </Folder>
-  <Folder Name="/src/submodules/">
-    <File Path="src/submodules/Directory.Build.props" />
-    <File Path="src/submodules/Directory.Packages.props" />
-    <Project Path="src/submodules/DotNet-BlueZ/src/DotNetBlueZ.csproj" />
-  </Folder>
   <Folder Name="/test/">
     <File Path="test/Directory.Build.props" />
     <Project Path="test/NRuuviTag.Core.Tests/NRuuviTag.Core.Tests.csproj" />

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
-  "Minor": 0,
-  "Patch": 1,
+  "Minor": 1,
+  "Patch": 0,
   "PreRelease": ""
 }

--- a/src/NRuuviTag.Cli.Linux/Properties/PublishProfiles/linux-arm.pubxml
+++ b/src/NRuuviTag.Cli.Linux/Properties/PublishProfiles/linux-arm.pubxml
@@ -8,7 +8,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
         <Platform>Any CPU</Platform>
         <PublishDir>..\..\artifacts\publish\$(Configuration)\NRuuviTag.Cli\linux-arm\</PublishDir>
         <PublishProtocol>FileSystem</PublishProtocol>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
         <SelfContained>true</SelfContained>
         <PublishSingleFile>true</PublishSingleFile>

--- a/src/NRuuviTag.Cli.Linux/Properties/PublishProfiles/linux-arm64.pubxml
+++ b/src/NRuuviTag.Cli.Linux/Properties/PublishProfiles/linux-arm64.pubxml
@@ -8,7 +8,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
         <Platform>Any CPU</Platform>
         <PublishDir>..\..\artifacts\publish\$(Configuration)\NRuuviTag.Cli\linux-arm64\</PublishDir>
         <PublishProtocol>FileSystem</PublishProtocol>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
         <SelfContained>true</SelfContained>
         <PublishSingleFile>true</PublishSingleFile>

--- a/src/NRuuviTag.Cli.Linux/Properties/PublishProfiles/linux-x64.pubxml
+++ b/src/NRuuviTag.Cli.Linux/Properties/PublishProfiles/linux-x64.pubxml
@@ -8,7 +8,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
         <Platform>Any CPU</Platform>
         <PublishDir>..\..\artifacts\publish\$(Configuration)\NRuuviTag.Cli\linux-x64\</PublishDir>
         <PublishProtocol>FileSystem</PublishProtocol>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
         <SelfContained>true</SelfContained>
         <PublishSingleFile>true</PublishSingleFile>

--- a/src/NRuuviTag.Cli.Windows/Properties/PublishProfiles/win-arm64.pubxml
+++ b/src/NRuuviTag.Cli.Windows/Properties/PublishProfiles/win-arm64.pubxml
@@ -8,7 +8,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
         <Platform>Any CPU</Platform>
         <PublishDir>..\..\artifacts\publish\$(Configuration)\NRuuviTag.Cli\win-arm64\</PublishDir>
         <PublishProtocol>FileSystem</PublishProtocol>
-        <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+        <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
         <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
         <SelfContained>false</SelfContained>
         <PublishSingleFile>true</PublishSingleFile>

--- a/src/NRuuviTag.Cli.Windows/Properties/PublishProfiles/win-x64.pubxml
+++ b/src/NRuuviTag.Cli.Windows/Properties/PublishProfiles/win-x64.pubxml
@@ -8,7 +8,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
         <Platform>Any CPU</Platform>
         <PublishDir>..\..\artifacts\publish\$(Configuration)\NRuuviTag.Cli\win-x64\</PublishDir>
         <PublishProtocol>FileSystem</PublishProtocol>
-        <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+        <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
         <SelfContained>false</SelfContained>
         <PublishSingleFile>true</PublishSingleFile>

--- a/src/NRuuviTag.Listener.Linux/BlueZListener.cs
+++ b/src/NRuuviTag.Listener.Linux/BlueZListener.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 
-using HashtagChris.DotNetBlueZ;
+using Linux.Bluetooth;
 
 using Microsoft.Extensions.Logging;
 
@@ -128,7 +128,7 @@ namespace NRuuviTag.Listener.Linux {
 
             // Adds a watcher for the specified device so that we can emit new samples when the
             // device properties change.
-            async Task<bool> AddDeviceWatcher(HashtagChris.DotNetBlueZ.Device device, Device1Properties properties) {
+            async Task<bool> AddDeviceWatcher(global::Linux.Bluetooth.Device device, Device1Properties properties) {
                 if (!running || cancellationToken.IsCancellationRequested) {
                     return false;
                 }

--- a/src/NRuuviTag.Listener.Linux/NRuuviTag.Listener.Linux.csproj
+++ b/src/NRuuviTag.Listener.Linux/NRuuviTag.Listener.Linux.csproj
@@ -6,21 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Linux.Bluetooth" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Tmds.DBus" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\submodules\DotNet-BlueZ\src\DotNetBlueZ.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\NRuuviTag.Core\NRuuviTag.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\submodules\DotNet-BlueZ\src\bin\$(Configuration)\$(TargetFramework)\DotNetBlueZ.dll">
-      <Pack>true</Pack>
-      <PackagePath>lib\$(TargetFramework)</PackagePath>
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
   
   <ItemGroup>

--- a/src/submodules/Directory.Build.props
+++ b/src/submodules/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <SignOutput>false</SignOutput>
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-    <IncludeDevelopmentPackages>false</IncludeDevelopmentPackages>
-  </PropertyGroup>
-</Project>
-

--- a/src/submodules/Directory.Packages.props
+++ b/src/submodules/Directory.Packages.props
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
This PR removes the use of the custom DotNet-BlueZ submodule and replaces it with Linux.Bluetooth. DotNet-BlueZ has more-or-less been abandoned upstream and Linux.Bluetooth offers a fairly straightforward drop-in replacement.