### PR TITLE
Update docs following DotNet-BlueZ removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The repository contains a [core library](/src/NRuuviTag.Core) that defines commo
 The repository contains the following listener implementations:
 
 - [Windows](/src/NRuuviTag.Listener.Windows) (using the Windows 10 SDK)
-- [Linux](/src/NRuuviTag.Listener.Linux) (using a modified version of [DotNet-BlueZ](https://github.com/wazzamatazz/DotNet-BlueZ) to receive advertisements from BlueZ's D-Bus APIs)
+- [Linux](/src/NRuuviTag.Listener.Linux) (using [Linux.Bluetooth](https://www.nuget.org/packages/Linux.Bluetooth/) to receive advertisements from BlueZ's D-Bus APIs)
 
 The `nruuvitag` [command-line tool](#command-line-application) can be used to as a turnkey solution to start receiving and publishing RuuviTag sensor data to an MQTT server or Azure Event Hub.
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -6,10 +6,3 @@ bring it to our attention by [creating an issue](https://github.com/wazzamatazz/
 
 The attached notices are provided for information only.
 
-
-### Licence notice for DotNet-BlueZ
-
-This repository uses a modified version of [DotNet-BlueZ](https://github.com/hashtagchris/DotNet-BlueZ), licensed under the [Apache License 2.0](https://github.com/hashtagchris/DotNet-BlueZ/blob/main/LICENSE).
-
-DotNet-BlueZ is copyright (c) hashtagchris.
-


### PR DESCRIPTION
Replaced references to DotNet-BlueZ with Linux.Bluetooth in README and removed DotNet-BlueZ license notice from THIRD-PARTY-NOTICES.md to reflect the updated dependency.