### PR TITLE
Preparation for public container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,55 @@ The command-line application can be run as a Linux service using systemd. See [h
 
 # Linux Container Image
 
-The command-line application can be run as a Linux container image. See [here](/docs/Docker.md) for details. Note that the container runs as the `root` user to allow BlueZ to access the Bluetooth adapter.
+The command-line application can be run on Linux as a container image. First, create a `$HOME/.nruuvitag` directory if you have not done so already:
+
+```sh
+mkdir $HOME/.nruuvitag
+```
+
+Then, run the container image as follows:
+
+```sh
+docker run -it --rm \
+    -v /var/run/dbus:/var/run/dbus \
+    -v $HOME/.nruuvitag:/root/.nruuvitag \
+    ghcr.io/wazzamatazz/nruuvitag:latest
+```
+
+> [!WARNING]
+> Note that the container runs as the `root` user to allow BlueZ to access the Bluetooth adapter.
+
+The container requires that the following volumes are mapped:
+
+- `/var/run/dbus` - Enables the container to communicate with DBus to receive Bluetooth advertisements.
+- `$HOME/.nruuvitag` - Allows the container to read from/write to the `devices.json` file that stores known devices.
+
+You can append the command arguments to the end of the call to `docker run` e.g. to list known devices:
+
+```sh
+docker run -it --rm \
+    -v /var/run/dbus:/var/run/dbus \
+    -v $HOME/.nruuvitag:/root/.nruuvitag \
+    ghcr.io/wazzamatazz/nruuvitag:latest \
+    devices list
+```
+
+You can also alias the command as follows:
+
+```sh
+alias nruuvitag='docker run -it --rm -v /var/run/dbus:/var/run/dbus -v $HOME/.nruuvitag:/root/.nruuvitag ghcr.io/wazzamatazz/nruuvitag:latest'
+export nruuvitag
+```
+
+To persist the alias, add the above commands to your shell's configuration file (e.g. `~/.bash_aliases`).
+
+Once you have created the alias, you can invoke the `nruuvitag` command as if it were installed on your host machine:
+
+```sh
+nruuvitag devices list
+```
+
+See [here](/docs/Docker.md) for details about how to build the image. 
 
 
 # Building the Solution

--- a/build.cake
+++ b/build.cake
@@ -48,13 +48,9 @@ const string VersionFile = "./build/version.json";
 //   The container registry to use when the PublishContainer target is specified.
 //     Default: Local Docker or Podman daemon
 //
-// --container-os=<OS>
-//   The container operating system to use when the PublishContainer target is specified.
-//     Default: linux
-//
-// --container-arch=<ARCHITECTURE>
-//   The container processor architecture to use when the PublishContainer target is specified.
-//     Default: Same as current machine
+// --container-rid=<RUNTIME IDENTIFIER>
+//   The runtime identifier to build the container image for when calling the PublishContainer target.
+//     Default: Inferred from the RuntimeIdentifier or RuntimeIdentifiers build property
 //
 // --property=<PROPERTY>
 //   Specifies an additional property to pass to MSBuild during Build and Pack targets. The value
@@ -73,7 +69,7 @@ const string VersionFile = "./build/version.json";
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=4.0.1
+#load nuget:?package=Jaahas.Cake.Extensions&version=5.0.0
 
 // Bootstrap build context and tasks.
 Bootstrap(

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
-  "Major": 2,
-  "Minor": 1,
+  "Major": 3,
+  "Minor": 0,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -16,15 +16,13 @@ To build a Linux container image for the NRuuviTag CLI application, run the 'Pub
 ./build.sh --target PublishContainer --configuration Release
 ``` 
 
-The default settings publish an x64 Linux image to the local Docker or Podman registry. To publish an image for a different architecture (e.g. `arm64`) specify the `--container-arch` parameter when running the build script. You can also publish the image to an alternative container registry by specifying the `--container-registry` parameter. For example:
+The default settings publish x64, arm and arm64 Linux images to the local Docker or Podman registry. You can also publish the image to an alternative container registry by specifying the `--container-registry` parameter. For example:
 
 **PowerShell**
 
 ```pwsh
 .\build.ps1 `
     --target PublishContainer `
-    --configuration Release `
-    --container-arch arm64 `
     --container-registry myregistry.mymachine.local:5000
 ``` 
 
@@ -33,8 +31,6 @@ The default settings publish an x64 Linux image to the local Docker or Podman re
 ```sh
 ./build.sh \
     --target PublishContainer \
-    --configuration Release \
-    --container-arch arm64 \
     --container-registry myregistry.mymachine.local:5000
 ``` 
 
@@ -58,7 +54,7 @@ Run the application as follows:
 docker run -it --rm \
     -v /var/run/dbus:/var/run/dbus \
     -v $HOME/.nruuvitag:/root/.nruuvitag \
-    nruuvitag:latest
+    wazzamatazz/nruuvitag:latest
 ```
 
 You can append the command arguments to the end of the call to `docker run` e.g. to list known devices:

--- a/src/NRuuviTag.Cli.Linux/NRuuviTag.Cli.Linux.csproj
+++ b/src/NRuuviTag.Cli.Linux/NRuuviTag.Cli.Linux.csproj
@@ -6,11 +6,17 @@
     <AssemblyName>nruuvitag</AssemblyName>
     <Description>Command-line tool that can receive broadcasts from RuuviTag IoT sensors and publish readings to a destination.</Description>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-    <!-- Use root so that the container can access the Bluetooth adapter -->
-    <ContainerUser>root</ContainerUser>
     <UserSecretsId>ef771434-9cd9-4037-b363-b7ca31975c30</UserSecretsId>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <ContainerRepository>wazzamatazz/nruuvitag</ContainerRepository>
+    <ContainerImageTags>latest;$(MajorVersion)</ContainerImageTags>
+    <!-- Container uses root so that it can access the Bluetooth adapter -->
+    <ContainerUser>root</ContainerUser>
+    <PrivateRepositoryUrl>$(PackageProjectUrl)</PrivateRepositoryUrl>
+  </PropertyGroup>
+  
   <ItemGroup>
     <None Remove="nruuvitag.service" />
   </ItemGroup>


### PR DESCRIPTION
## ⚠️ Breaking Changes

- Renames the container repository from `nruuvitag` to `wazzamatazz/nruuvitag` in preparation for publishing container image to GitHub Container Registry.
- Adds instructions to README for running container using public image.