### PR TITLE
Listener now uses scoped lifetime

### DIFF
--- a/src/NRuuviTag.Cli/NRuuviTagHostBuilderExtensions.cs
+++ b/src/NRuuviTag.Cli/NRuuviTagHostBuilderExtensions.cs
@@ -43,8 +43,6 @@ public static class NRuuviTagHostBuilderExtensions {
         ArgumentNullException.ThrowIfNull(args);
 
         builder.ConfigureServices((context, services) => {
-            services.AddHttpClient<NRuuviTag.Http.HttpPublisher>().AddStandardResilienceHandler();
-            
             services.AddOpenTelemetry()
                 .ConfigureResource(resource => resource.AddService<DeviceCollection>())
                 .AddOtlpExporter(context.Configuration)

--- a/src/NRuuviTag.Cli/NRuuviTagServiceCollectionExtensions.cs
+++ b/src/NRuuviTag.Cli/NRuuviTagServiceCollectionExtensions.cs
@@ -44,7 +44,7 @@ public static class NRuuviTagServiceCollectionExtensions {
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddCoreRuuviTagServices(configuration);
-        services.AddTransient<IRuuviTagListener, TListener>();
+        services.AddScoped<IRuuviTagListener, TListener>();
 
         return services;
     }
@@ -84,7 +84,7 @@ public static class NRuuviTagServiceCollectionExtensions {
         ArgumentNullException.ThrowIfNull(factory);
 
         services.AddCoreRuuviTagServices(configuration);
-        services.AddTransient<IRuuviTagListener, TListener>(factory);
+        services.AddScoped<IRuuviTagListener, TListener>(factory);
 
         return services;
     }
@@ -106,6 +106,7 @@ public static class NRuuviTagServiceCollectionExtensions {
         services.Configure<DeviceCollection>(configuration.GetSection("Devices"));
 
         services.AddTransient<MqttFactory>();
+        services.AddHttpClient<NRuuviTag.Http.HttpPublisher>().AddStandardResilienceHandler();
 
         services.AddSpectreCommandApp(CommandUtilities.ConfigureCommandApp);
 


### PR DESCRIPTION
## :warning: Breaking Changes

`NRuuviTagServiceCollectionExtensions` now registers the `IRuuviTagListener` as a scoped service instead of transient. This is a breaking change but makes no practical difference in the CLI since a new scope is already created for the Spectre command app.

The registration of the HTTP client for the HTTP publisher has been moved to the `NRuuviTagServiceCollectionExtensions.AddCoreRuuviTagServices` method.