### PR TITLE
Add custom BlueZ discovery filter

### DIFF
--- a/src/NRuuviTag.Listener.Linux/BlueZListener.cs
+++ b/src/NRuuviTag.Listener.Linux/BlueZListener.cs
@@ -75,6 +75,13 @@ public partial class BlueZListener : RuuviTagListener {
         // Registrations for devices that we are observing.
         var watchers = new Dictionary<string, IDisposable>(StringComparer.OrdinalIgnoreCase);
 
+        // Set BlueZ discovery filter to receive LE advertisements and to allow duplicates.
+        await adapter.SetDiscoveryFilterAsync(
+            new Dictionary<string, object>() {
+                ["Transport"] = "le",
+                ["DuplicateData"] = true
+            }).ConfigureAwait(false);
+        
         // Handler for when BlueZ detects a new device.
         adapter.DeviceFound += async (_, args) => {
             var disposeDevice = false;


### PR DESCRIPTION
Adds a discovery filter to the BlueZ listener to allow duplicate advertisements to be processed. This should help Linux systems to receive RuuviTag advertisements more frequently.