### PR TITLE
Pre-release container images use 'preview' tag

### DIFF
--- a/src/NRuuviTag.Cli.Linux/NRuuviTag.Cli.Linux.csproj
+++ b/src/NRuuviTag.Cli.Linux/NRuuviTag.Cli.Linux.csproj
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <ContainerRepository>wazzamatazz/nruuvitag</ContainerRepository>
     <ContainerImageTags Condition=" '$(IsPrereleaseVersion)' != 'true' ">latest;$(MajorVersion)</ContainerImageTags>
-    <ContainerImageTags Condition=" '$(IsPrereleaseVersion)' == 'true' ">$(MajorVersion)-preview</ContainerImageTags>
+    <ContainerImageTags Condition=" '$(IsPrereleaseVersion)' == 'true' ">preview;$(MajorVersion)-preview</ContainerImageTags>
     <!-- Container uses root so that it can access the Bluetooth adapter -->
     <ContainerUser>root</ContainerUser>
     <PrivateRepositoryUrl>$(PackageProjectUrl)</PrivateRepositoryUrl>


### PR DESCRIPTION
Container images for pre-release versions will now be tagged with `preview` as well as `{MAJOR}-preview`. This is intended to provide a means of always using the latest preview version.