### PR TITLE
Update NuGet packages to their latest versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,35 +5,35 @@
     <NoWarn>NU1507;$(NoWarn)</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <GlobalPackageReference Include="MinVer" Version="6.0.0" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <GlobalPackageReference Include="MinVer" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="Cake.MinVer" Version="4.0.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Jaahas.CertificateUtilities" Version="1.2.0" />
     <PackageVersion Include="Jaahas.OpenTelemetry.Extensions" Version="3.0.0" />
     <PackageVersion Include="Jaahas.Spectre.Extensions.Hosting" Version="3.0.0" />
     <PackageVersion Include="Linux.Bluetooth" Version="6.0.0-pre2" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
-    <PackageVersion Include="MQTTnet" Version="5.0.1.1416" />
-    <PackageVersion Include="MQTTnet.Server" Version="5.0.1.1416" />
-    <PackageVersion Include="MSTest" Version="4.0.2" />
+    <PackageVersion Include="MQTTnet" Version="5.2.0.1603" />
+    <PackageVersion Include="MQTTnet.Server" Version="5.2.0.1603" />
+    <PackageVersion Include="MSTest" Version="4.2.3" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.14.0" />
-    <PackageVersion Include="Polly.Core" Version="8.6.5" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
+    <PackageVersion Include="Polly.Core" Version="8.7.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="Tmds.DBus" Version="0.22.0" />
+    <PackageVersion Include="Tmds.DBus" Version="0.94.2" />
   </ItemGroup>
 </Project>

--- a/src/NRuuviTag.Cli/Commands/DeviceAddCommand.cs
+++ b/src/NRuuviTag.Cli/Commands/DeviceAddCommand.cs
@@ -39,7 +39,7 @@ public class DeviceAddCommand : AsyncCommand<DeviceAddCommand.Settings> {
 
 
     /// <inheritdoc/>
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
         var device = new Device() { 
             MacAddress = settings.MacAddress,
             DisplayName = settings.DisplayName,

--- a/src/NRuuviTag.Cli/Commands/DeviceListCommand.cs
+++ b/src/NRuuviTag.Cli/Commands/DeviceListCommand.cs
@@ -30,7 +30,7 @@ public class DeviceListCommand : Command<DeviceListCommand.Settings> {
 
 
     /// <inheritdoc/>
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken) {
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken) {
         Console.WriteLine();
         CommandUtilities.PrintDevicesToConsole(_devices);
         Console.WriteLine();

--- a/src/NRuuviTag.Cli/Commands/DeviceRemoveCommand.cs
+++ b/src/NRuuviTag.Cli/Commands/DeviceRemoveCommand.cs
@@ -36,7 +36,7 @@ public class DeviceRemoveCommand : AsyncCommand<DeviceRemoveCommand.Settings> {
 
 
     /// <inheritdoc/>
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
         if (_devices == null || _devices.Count == 0) {
             // No devices defined
             Console.WriteLine(string.Format(CultureInfo.CurrentCulture, Resources.LogMessage_DeviceNotFound, settings.Device));

--- a/src/NRuuviTag.Cli/Commands/DeviceScanCommand.cs
+++ b/src/NRuuviTag.Cli/Commands/DeviceScanCommand.cs
@@ -50,7 +50,7 @@ public class DeviceScanCommand : AsyncCommand<DeviceScanCommand.Settings> {
 
 
     /// <inheritdoc/>
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
         // Wait until the host application has started if required.
         if (!_appLifetime.ApplicationStarted.IsCancellationRequested) {
             try { await Task.Delay(-1, _appLifetime.ApplicationStarted).ConfigureAwait(false); }

--- a/src/NRuuviTag.Cli/Commands/PublishAzureEventHubCommand.cs
+++ b/src/NRuuviTag.Cli/Commands/PublishAzureEventHubCommand.cs
@@ -58,7 +58,7 @@ public class PublishAzureEventHubCommand : AsyncCommand<PublishAzureEventHubComm
 
 
     /// <inheritdoc/>
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
         if (!_appLifetime.ApplicationStarted.IsCancellationRequested) {
             try { await Task.Delay(Timeout.InfiniteTimeSpan, _appLifetime.ApplicationStarted).ConfigureAwait(false); }
             catch (OperationCanceledException) when (_appLifetime.ApplicationStarted.IsCancellationRequested) { }

--- a/src/NRuuviTag.Cli/Commands/PublishConsoleCommand.cs
+++ b/src/NRuuviTag.Cli/Commands/PublishConsoleCommand.cs
@@ -42,7 +42,7 @@ public class PublishConsoleCommand : AsyncCommand<PublishConsoleCommand.Settings
 
 
     /// <inheritdoc/>
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
         // Wait until the host application has started if required.
         if (!_appLifetime.ApplicationStarted.IsCancellationRequested) {
             try { await Task.Delay(-1, _appLifetime.ApplicationStarted).ConfigureAwait(false); }

--- a/src/NRuuviTag.Cli/Commands/PublishHttpCommand.cs
+++ b/src/NRuuviTag.Cli/Commands/PublishHttpCommand.cs
@@ -67,7 +67,7 @@ public class PublishHttpCommand : AsyncCommand<PublishHttpCommand.Settings> {
 
 
     /// <inheritdoc />
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
         if (!_appLifetime.ApplicationStarted.IsCancellationRequested) {
             try { await Task.Delay(-1, _appLifetime.ApplicationStarted).ConfigureAwait(false); }
             catch (OperationCanceledException) { }

--- a/src/NRuuviTag.Cli/Commands/PublishMqttCommand.cs
+++ b/src/NRuuviTag.Cli/Commands/PublishMqttCommand.cs
@@ -78,7 +78,7 @@ public class PublishMqttCommand : AsyncCommand<PublishMqttCommand.Settings> {
 
 
     /// <inheritdoc/>
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken) {
         if (!_appLifetime.ApplicationStarted.IsCancellationRequested) {
             try { await Task.Delay(-1, _appLifetime.ApplicationStarted).ConfigureAwait(false); }
             catch (OperationCanceledException) { }


### PR DESCRIPTION
## Summary
- Bumps all centrally-managed package versions in `Directory.Packages.props` to their latest releases (MSTest, MQTTnet, Spectre.Console.Cli, Tmds.DBus, OpenTelemetry.Api, Microsoft.Extensions.*, Polly.Core, MinVer, SourceLink, coverlet, etc.)
- The `Spectre.Console.Cli` 0.55.0 upgrade tightens access-modifier checks on `AsyncCommand<T>.ExecuteAsync`/`Command<T>.Execute` overrides, so all 8 CLI command classes were updated from `public override` to `protected override` to match the base class signature

## Test plan
- [x] `./build.sh --target=Build` succeeds with 0 errors
- [x] `./build.sh --target=Test` passes (22/22 tests)
- [x] `dotnet list package --outdated` reports nothing outdated

🤖 Generated with [Claude Code](https://claude.com/claude-code)