### PR TITLE
Migrate tests from VSTest to Microsoft.Testing.Platform (MTP)

### DIFF
--- a/build/cake.cs
+++ b/build/cake.cs
@@ -1,10 +1,10 @@
-#:sdk Cake.Sdk@6.0.0
+#:sdk Cake.Sdk@6.2.0
 #:package Cake.MinVer
 
 using System.Collections.Immutable;
 
-InstallTool("dotnet:https://api.nuget.org/v3/index.json?package=minver-cli&version=6.0.0");
-InstallTool("dotnet:https://api.nuget.org/v3/index.json?package=CycloneDX&version=5.5.0");
+InstallTool("dotnet:https://api.nuget.org/v3/index.json?package=minver-cli&version=7.0.0");
+InstallTool("dotnet:https://api.nuget.org/v3/index.json?package=CycloneDX&version=6.2.0");
 
 var target = Argument("target", "Default");
 var ciBuild = !BuildSystem.IsLocalBuild || HasArgument("ci");

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -11,6 +11,7 @@
     <SignOutput>false</SignOutput>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
     <IncludeDevelopmentPackages>false</IncludeDevelopmentPackages>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
   </PropertyGroup>
 
 </Project>

--- a/test/NRuuviTag.Core.Tests/TestRuuviTagListener.cs
+++ b/test/NRuuviTag.Core.Tests/TestRuuviTagListener.cs
@@ -30,7 +30,7 @@ public sealed class TestRuuviTagListener : RuuviTagListener {
         var channel = Channel.CreateUnbounded<RuuviTagSample>(new UnboundedChannelOptions() { 
             SingleReader = true,
             SingleWriter = true,
-            AllowSynchronousContinuations = true
+            AllowSynchronousContinuations = false
         });
         _subscriptions[channelId] = channel;
         

--- a/test/NRuuviTag.Http.Tests/NRuuviTag.Http.Tests.csproj
+++ b/test/NRuuviTag.Http.Tests/NRuuviTag.Http.Tests.csproj
@@ -5,6 +5,7 @@
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/NRuuviTag.Mqtt.Tests/NRuuviTag.Mqtt.Tests.csproj
+++ b/test/NRuuviTag.Mqtt.Tests/NRuuviTag.Mqtt.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Summary:**
- Switch test projects to the Microsoft.Testing.Platform (MTP) runner via `global.json` (`test.runner`) and `EnableMSTestRunner` in `test/Directory.Build.props`, making `NRuuviTag.Http.Tests` and `NRuuviTag.Mqtt.Tests` executable (`OutputType=Exe`) as MTP requires
- Set `AllowSynchronousContinuations = false` on the channel in `TestRuuviTagListener` to avoid deadlock/ordering issues under the new runner
- Bump the Cake SDK to 6.2.0 and update `minver-cli` (6.0.0 → 7.0.0) and `CycloneDX` (5.5.0 → 6.2.0) tool versions used by the build script

**Test plan:**
- [x] `./build.sh` runs clean and all test projects execute successfully under MTP

**Known issues:**
- Migrating to MTP does not fix existing test timeout issues when running multiple test projects in parallel