### PR TITLE
Fix test timeouts caused by publish race in TestRuuviTagListener

### DIFF
--- a/test/NRuuviTag.Core.Tests/TestRuuviTagListener.cs
+++ b/test/NRuuviTag.Core.Tests/TestRuuviTagListener.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Channels;
@@ -8,55 +7,51 @@ using System.Threading.Tasks;
 namespace NRuuviTag;
 
 /// <summary>
-/// <see cref="RuuviTagListener"/> implementation that allows ad hoc samples to be emitted to 
+/// <see cref="RuuviTagListener"/> implementation that allows ad hoc samples to be emitted to
 /// subscribers on demand.
 /// </summary>
 public sealed class TestRuuviTagListener : RuuviTagListener {
 
     /// <summary>
-    /// Active subscription channels.
+    /// Buffers published samples until the listener starts running.
     /// </summary>
-    private readonly ConcurrentDictionary<Guid, Channel<RuuviTagSample>> _subscriptions = [];
+    /// <remarks>
+    ///   The channel is created eagerly so that samples published before <see cref="RunAsync"/>
+    ///   has started are buffered instead of being dropped. <see cref="RunAsync"/> is started in
+    ///   a background task when a subscriber starts listening, so waiting for the listener to
+    ///   start before publishing samples is inherently racy.
+    /// </remarks>
+    private readonly Channel<RuuviTagSample> _channel = Channel.CreateUnbounded<RuuviTagSample>(new UnboundedChannelOptions() {
+        SingleReader = true,
+        SingleWriter = false,
+        AllowSynchronousContinuations = false
+    });
 
 
     /// <inheritdoc />
-    public TestRuuviTagListener(RuuviTagListenerOptions options, IDeviceResolver deviceResolver) 
+    public TestRuuviTagListener(RuuviTagListenerOptions options, IDeviceResolver deviceResolver)
         : base(options, deviceResolver) { }
 
 
     /// <inheritdoc/>
     protected override async Task RunAsync(CancellationToken cancellationToken) {
-        var channelId = Guid.NewGuid();
-        var channel = Channel.CreateUnbounded<RuuviTagSample>(new UnboundedChannelOptions() { 
-            SingleReader = true,
-            SingleWriter = true,
-            AllowSynchronousContinuations = false
-        });
-        _subscriptions[channelId] = channel;
-        
-        try {
-            await foreach (var item in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false)) { 
-                if (item?.MacAddress == null) {
-                    continue;
-                }
-
-                var device = DeviceResolver.GetDeviceInformation(item.MacAddress);
-                if (device is null && KnownDevicesOnly) {
-                    continue;
-                }
-
-                EmitSample(item);
+        await foreach (var item in _channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false)) {
+            if (item?.MacAddress == null) {
+                continue;
             }
-        }
-        finally {
-            _subscriptions.TryRemove(channelId, out _);
-            channel.Writer.TryComplete();
+
+            var device = DeviceResolver.GetDeviceInformation(item.MacAddress);
+            if (device is null && KnownDevicesOnly) {
+                continue;
+            }
+
+            EmitSample(item);
         }
     }
 
 
     /// <summary>
-    /// Publishes samples to all active subscription channels.
+    /// Publishes samples to the listener.
     /// </summary>
     /// <param name="samples">
     ///   The samples.
@@ -66,20 +61,15 @@ public sealed class TestRuuviTagListener : RuuviTagListener {
     /// </exception>
     public void Publish(params IReadOnlyList<RuuviTagSample> samples) {
         ArgumentNullException.ThrowIfNull(samples);
-        if (samples.Count == 0) {
-            return;
-        }
 
-        foreach (var channel in _subscriptions.Values) {
-            foreach (var sample in samples) {
-                channel.Writer.TryWrite(sample);
-            }
+        foreach (var sample in samples) {
+            _channel.Writer.TryWrite(sample);
         }
     }
-    
-    
+
+
     /// <summary>
-    /// Publishes samples to all active subscription channels.
+    /// Publishes samples to the listener.
     /// </summary>
     /// <param name="samples">
     ///   The samples.
@@ -89,14 +79,9 @@ public sealed class TestRuuviTagListener : RuuviTagListener {
     /// </exception>
     public async ValueTask PublishAsync(params IReadOnlyList<RuuviTagSample> samples) {
         ArgumentNullException.ThrowIfNull(samples);
-        if (samples.Count == 0) {
-            return;
-        }
 
-        foreach (var channel in _subscriptions.Values) {
-            foreach (var sample in samples) {
-                await channel.Writer.WriteAsync(sample);
-            }
+        foreach (var sample in samples) {
+            await _channel.Writer.WriteAsync(sample);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the frequent MQTT (and occasional HTTP) unit test timeouts. The root cause was a startup race in the shared `TestRuuviTagListener` test helper, not in the MQTT publishing code — which matches the MQTT functionality working correctly in real-world usage.

## Root cause

`TestRuuviTagListener` created and registered its subscription channel inside `RunAsync`, which is started in a background task when a publisher begins listening. The tests all follow this pattern:

```csharp
_ = bridge.RunAsync(ctSource.Token);   // queues listener startup in the background
listener.Publish(sample);              // runs immediately on the test thread
```

If `Publish` ran before the background task had registered the channel, the sample was silently dropped. Since each test publishes exactly one sample, nothing ever reached the broker and the test waited out its full 15-second timeout before failing with `TaskCanceledException`. Under the MSTest host's scheduling the race was lost almost every time; instrumentation showed `Publish` and the subscription registration landing in the same millisecond, and adding a sub-millisecond delay inside `Publish` flipped the tests to passing.

## Fix

The listener now creates a single unbounded buffer channel eagerly at construction. `Publish`/`PublishAsync` always write into it and `RunAsync` drains it, so samples published before the listener starts running are buffered and delivered once it does. No product code or test changes are required, and all current usages of the helper have single-publisher semantics, so the multi-subscription dictionary is no longer needed.

## Verification

- MQTT tests: 10/10 consecutive runs green, suite duration dropped from 15s (all tests failing) to ~160ms.
- Core tests: 5/5 runs green.
- HTTP tests (same helper, same latent race): 5/5 runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)