### PR TITLE
Ensure that Linux BLE adapter is powered on

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Jaahas.CertificateUtilities" Version="1.2.0" />
     <PackageVersion Include="Jaahas.OpenTelemetry.Extensions" Version="3.0.0" />
     <PackageVersion Include="Jaahas.Spectre.Extensions.Hosting" Version="3.0.0" />
-    <PackageVersion Include="Linux.Bluetooth" Version="6.0.0-pre2" />
+    <PackageVersion Include="Linux.Bluetooth" Version="6.0.0-pre3" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.9" />

--- a/src/NRuuviTag.Listener.Linux/BlueZListener.cs
+++ b/src/NRuuviTag.Listener.Linux/BlueZListener.cs
@@ -63,9 +63,10 @@ public partial class BlueZListener : RuuviTagListener {
 
     /// <inheritdoc/>
     protected override async Task RunAsync(CancellationToken cancellationToken) {
-        // Get the adapter from BlueZ.
+        // Get the adapter from BlueZ and power it on.
         using var adapter = await BlueZManager.GetAdapterAsync(_adapterName).ConfigureAwait(false);
-            
+        await adapter.SetPoweredAsync(true);
+        
         // Registrations for devices that we are observing.
         var watchers = new ConcurrentDictionary<string, IDisposable>(StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
When running the Linux listener, a race condition can occur (particularly inside a container) where the listener attempts to access the adapter before it has finished initialising:

```
Tmds.DBus.DBusException: org.bluez.Error.NotReady: Resource Not Ready
```

This PR mitigates the issue by explicitly requesting that the adapter is powered on before attempting to start scanning for Ruuvi devices.