### PR TITLE
Remove use of Jaahas.OpenTelemetry.Extensions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MinVerMinimumMajorMinor>5.0</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>6.0</MinVerMinimumMajorMinor>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <MinVerDefaultPreReleaseIdentifiers>pre.0</MinVerDefaultPreReleaseIdentifiers>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,6 @@
     <PackageVersion Include="Cake.MinVer" Version="4.0.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Jaahas.CertificateUtilities" Version="1.2.0" />
-    <PackageVersion Include="Jaahas.OpenTelemetry.Extensions" Version="3.0.0" />
     <PackageVersion Include="Jaahas.Spectre.Extensions.Hosting" Version="3.0.0" />
     <PackageVersion Include="Linux.Bluetooth" Version="6.0.0-pre3" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
@@ -31,6 +30,8 @@
     <PackageVersion Include="MSTest" Version="4.2.3" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="Polly.Core" Version="8.7.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/README.md
+++ b/README.md
@@ -242,9 +242,14 @@ See [here](/docs/Docker.md) for details about how to build the image.
 The command-line application can be run as a Linux service using systemd. See [here](/docs/LinuxSystemdService.md) for details.
 
 
+# OpenTelemetry
+
+Logs and metrics are automatically exported to an OTLP-compatible endpoint if standard OpenTelemetry environment variables are set. See [here](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/) for details about configuring OpenTelemetry.
+
+
 # Building the Solution
 
-The repository uses [Cake](https://cakebuild.net/) for cross-platform build automation. The build script allows for metadata such as a build counter to be specified when called by a continuous integration system such as TeamCity.
+The repository uses [Cake](https://cakebuild.net/) for cross-platform build automation.
 
 A build can be run from the command line using the [build.ps1](/build.ps1) PowerShell script or the [build.sh](/build.sh) Bash script. For documentation about the available build script parameters, run the script without any arguments.
 

--- a/build/cake.cs
+++ b/build/cake.cs
@@ -3,6 +3,9 @@
 
 using System.Collections.Immutable;
 
+// MinVer minimum major.minor version to use.
+var minimumMajorMinorVersion = "6.0";
+
 InstallTool("dotnet:https://api.nuget.org/v3/index.json?package=minver-cli&version=7.0.0");
 InstallTool("dotnet:https://api.nuget.org/v3/index.json?package=CycloneDX&version=6.2.0");
 
@@ -58,8 +61,9 @@ Setup<BuildData>(context => {
     
     var version = MinVer(settings => settings
         .WithTagPrefix("v")
-        .WithVerbosity(MinVerVerbosity.Info)
-    );
+        .WithDefaultPreReleasePhase("pre")
+        .WithMinimumMajorMinor(minimumMajorMinorVersion)
+        .WithVerbosity(MinVerVerbosity.Info));
     
     Environment.SetEnvironmentVariable("ContinuousIntegrationBuild", ciBuild ? "true" : "false");
     Environment.SetEnvironmentVariable("MinVerVersionOverride", version);

--- a/src/NRuuviTag.Cli/AssemblyAttributes.cs
+++ b/src/NRuuviTag.Cli/AssemblyAttributes.cs
@@ -1,1 +1,0 @@
-﻿[assembly: Jaahas.OpenTelemetry.OpenTelemetryService("nruuvitag-cli")]

--- a/src/NRuuviTag.Cli/NRuuviTag.Cli.csproj
+++ b/src/NRuuviTag.Cli/NRuuviTag.Cli.csproj
@@ -8,10 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Jaahas.CertificateUtilities" />
-    <PackageReference Include="Jaahas.OpenTelemetry.Extensions" />
     <PackageReference Include="Jaahas.Spectre.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Spectre.Console.Cli" />
   </ItemGroup>
 

--- a/src/NRuuviTag.Cli/NRuuviTagHostBuilderExtensions.cs
+++ b/src/NRuuviTag.Cli/NRuuviTagHostBuilderExtensions.cs
@@ -4,8 +4,6 @@ using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
 
-using NRuuviTag.Cli;
-
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -43,16 +41,14 @@ public static class NRuuviTagHostBuilderExtensions {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(args);
 
-        builder.ConfigureServices((context, services) => {
+        builder.ConfigureServices((_, services) => {
             services.AddOpenTelemetry()
-                .ConfigureResource(resource => resource.AddService<DeviceCollection>())
-                .AddOtlpExporter(context.Configuration)
-                .WithLogging(null, options => {
-                    options.IncludeFormattedMessage = true;
-                })
-                .WithMetrics(metrics => { 
-                    metrics.AddNRuuviTagInstrumentation();
-                });
+                .ConfigureResource(resource => resource.AddService(
+                    "nruuvitag-cli", 
+                    serviceVersion: typeof(NRuuviTagHostBuilderExtensions).Assembly.GetName().Version?.ToString(3)))
+                .WithLogging(null, options => options.IncludeFormattedMessage = true)
+                .WithMetrics(metrics => metrics.AddNRuuviTagInstrumentation())
+                .UseOtlpExporter();
         });
             
         return await builder.BuildAndRunCommandAppAsync(args).ConfigureAwait(false);


### PR DESCRIPTION
## ⚠️ Breaking Change

Jaahas.OpenTelemetry.Extensions is mostly redundant since multi-signal OTLP export can be fully configured these days using standard environment variables. Removing this dependency ensures that we don't inherit vulnerable upstream OpenTelemetry package references.

This is a breaking change due to differences in how telemetry export is configured.