### PR TITLE
Add platform-specific data directory resolvers

### DIFF
--- a/src/NRuuviTag.Cli.Linux/LinuxDirectoryResolver.cs
+++ b/src/NRuuviTag.Cli.Linux/LinuxDirectoryResolver.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+
+namespace NRuuviTag.Cli.Linux;
+
+internal sealed class LinuxDirectoryResolver : IDirectoryResolver {
+
+    /// <inheritdoc />
+    public string GetConfigDirectory() {
+        var xdgConfigHome = Environment.ExpandEnvironmentVariables("%XDG_CONFIG_HOME%");
+        return string.IsNullOrWhiteSpace(xdgConfigHome) || xdgConfigHome.Equals("%XDG_CONFIG_HOME%", StringComparison.OrdinalIgnoreCase)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "nruuvitag") 
+            : Path.Combine(xdgConfigHome, "nruuvitag");
+    }
+
+
+    /// <inheritdoc />
+    public string GetDataDirectory() {
+        var xdgDataHome = Environment.ExpandEnvironmentVariables("%XDG_DATA_HOME%");
+        if (string.IsNullOrWhiteSpace(xdgDataHome) || xdgDataHome.Equals("%XDG_DATA_HOME%", StringComparison.OrdinalIgnoreCase)) {
+            xdgDataHome = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share");
+        }
+        
+        // If the XDG data directory does not exist, we'll fall back to the location used by
+        // nruuvitag v5 and earlier if it exists. Otherwise, we'll use the XDG data directory.
+        
+        var path = Path.Combine(xdgDataHome, "nruuvitag");
+        if (Directory.Exists(path)) {
+            return path;
+        }
+
+        var fallbackDataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nruuvitag");
+        return Directory.Exists(fallbackDataDir) 
+            ? fallbackDataDir 
+            : path;
+    }
+
+}

--- a/src/NRuuviTag.Cli.Linux/Program.cs
+++ b/src/NRuuviTag.Cli.Linux/Program.cs
@@ -3,7 +3,7 @@
 using NRuuviTag.Cli;
 using NRuuviTag.Cli.Linux;
 
-return await NRuuviTagHostBuilder.CreateHostBuilder<BlueZListenerFactory>(args)
+return await NRuuviTagHostBuilder.CreateHostBuilder<BlueZListenerFactory>(args, new LinuxDirectoryResolver())
     .UseSystemd()
     .BuildHostAndRunNRuuviTagAsync(args)
     .ConfigureAwait(false);

--- a/src/NRuuviTag.Cli.Windows/Program.cs
+++ b/src/NRuuviTag.Cli.Windows/Program.cs
@@ -4,6 +4,6 @@ using NRuuviTag.Cli;
 using NRuuviTag.Cli.Windows;
 
 return await NRuuviTagHostBuilder
-    .CreateHostBuilder<WindowsSdkListenerFactory>(args)
+    .CreateHostBuilder<WindowsSdkListenerFactory>(args, new WindowsDirectoryResolver())
     .BuildHostAndRunNRuuviTagAsync(args)
     .ConfigureAwait(false);

--- a/src/NRuuviTag.Cli.Windows/WindowsDirectoryResolver.cs
+++ b/src/NRuuviTag.Cli.Windows/WindowsDirectoryResolver.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+
+namespace NRuuviTag.Cli.Windows;
+
+internal sealed class WindowsDirectoryResolver : IDirectoryResolver {
+
+    public string GetConfigDirectory() {
+        return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "NRuuviTag", "config");
+    }
+
+    public string GetDataDirectory() {
+        var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "NRuuviTag", "data");
+        
+        // If the data directory does not exist, we'll fall back to the location used by
+        // nruuvitag v5 and earlier if it exists. Otherwise, we'll use the default data directory.
+        
+        if (Directory.Exists(path)) {
+            return path;
+        }
+
+        var fallbackDataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nruuvitag");
+        return Directory.Exists(fallbackDataDir) 
+            ? fallbackDataDir 
+            : path;
+    }
+
+}

--- a/src/NRuuviTag.Cli/Commands/CommandUtilities.cs
+++ b/src/NRuuviTag.Cli/Commands/CommandUtilities.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-
-using Spectre.Console;
+﻿using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace NRuuviTag.Cli.Commands;
@@ -10,17 +7,6 @@ namespace NRuuviTag.Cli.Commands;
 /// Utility methods for use in <see cref="CommandApp"/> commands.
 /// </summary>
 internal static class CommandUtilities {
-
-    /// <summary>
-    /// Folder under the user's profile that the devices.json will be stored in.
-    /// </summary>
-    private const string LocalDataFolderName = ".nruuvitag";
-
-    /// <summary>
-    /// The file name that contains known devices.
-    /// </summary>
-    private const string DevicesJsonFileName = "devices.json";
-
 
     /// <summary>
     /// Configures the NRuuviTag command app.
@@ -78,42 +64,7 @@ internal static class CommandUtilities {
                 .WithExample(["devices", "remove", "\"Master Bedroom\""]);
         });
     }
-
-
-    /// <summary>
-    /// Gets a <see cref="FileInfo"/> object for the <c>devices.json</c> file containing known 
-    /// device configurations.
-    /// </summary>
-    /// <returns>
-    ///   A new <see cref="FileInfo"/> object.
-    /// </returns>
-    internal static FileInfo GetDevicesJsonFile() => GetDevicesJsonFile(null);
-
-
-    /// <summary>
-    /// Gets a <see cref="FileInfo"/> object for the <c>devices.json</c> file containing known 
-    /// device configurations.
-    /// </summary>
-    /// <param name="path">
-    ///   The path to the directory containing the <c>devices.json</c> file. Specify <see langword="null"/> 
-    ///   to use the <c>.nruuvitag</c> folder under the <see cref="Environment.SpecialFolder.UserProfile"/> 
-    ///   folder.
-    /// </param>
-    /// <returns>
-    ///   A new <see cref="FileInfo"/> object.
-    /// </returns>
-    internal static FileInfo GetDevicesJsonFile(string? path) {
-        if (string.IsNullOrEmpty(path)) {
-            path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), LocalDataFolderName);
-        }
-        if (!Path.IsPathRooted(path)) {
-            path = Path.GetFullPath(path, Environment.CurrentDirectory);
-        } 
-
-        return new FileInfo(Path.Combine(path, DevicesJsonFileName));
-    }
-
-
+    
     /// <summary>
     /// Prints information about the specified <see cref="DeviceCollection"/> to the console.
     /// </summary>

--- a/src/NRuuviTag.Cli/Commands/DeviceAddCommand.cs
+++ b/src/NRuuviTag.Cli/Commands/DeviceAddCommand.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 using NRuuviTag.Mqtt;
@@ -25,6 +24,11 @@ public class DeviceAddCommand : AsyncCommand<DeviceAddCommand.Settings> {
     /// The known devices.
     /// </summary>
     private readonly DeviceCollection _devices;
+    
+    /// <summary>
+    /// The <see cref="IDirectoryResolver"/> that is used to resolve the location of the devices file.
+    /// </summary>
+    private readonly IDirectoryResolver _directoryResolver;
 
 
     /// <summary>
@@ -33,8 +37,9 @@ public class DeviceAddCommand : AsyncCommand<DeviceAddCommand.Settings> {
     /// <param name="devices">
     ///   The known devices.
     /// </param>
-    public DeviceAddCommand(IOptions<DeviceCollection> devices) {
+    public DeviceAddCommand(IOptions<DeviceCollection> devices, IDirectoryResolver directoryResolver) {
         _devices = devices.Value;
+        _directoryResolver = directoryResolver;
     }
 
 
@@ -66,7 +71,7 @@ public class DeviceAddCommand : AsyncCommand<DeviceAddCommand.Settings> {
             Devices = _devices
         };
 
-        var devicesJsonFile = CommandUtilities.GetDevicesJsonFile();
+        var devicesJsonFile =_directoryResolver.GetDevicesDataFilePath();
 
         // Ensure directory exists.
         devicesJsonFile.Directory!.Create();

--- a/src/NRuuviTag.Cli/Commands/DeviceRemoveCommand.cs
+++ b/src/NRuuviTag.Cli/Commands/DeviceRemoveCommand.cs
@@ -22,6 +22,11 @@ public class DeviceRemoveCommand : AsyncCommand<DeviceRemoveCommand.Settings> {
     /// The known devices.
     /// </summary>
     private readonly DeviceCollection _devices;
+    
+    /// <summary>
+    /// The <see cref="IDirectoryResolver"/> that is used to resolve the location of the devices file.
+    /// </summary>
+    private readonly IDirectoryResolver _directoryResolver;
 
 
     /// <summary>
@@ -30,8 +35,12 @@ public class DeviceRemoveCommand : AsyncCommand<DeviceRemoveCommand.Settings> {
     /// <param name="devices">
     ///   The known devices.
     /// </param>
-    public DeviceRemoveCommand(IOptions<DeviceCollection> devices) {
+    /// <param name="directoryResolver">
+    ///   The <see cref="IDirectoryResolver"/> that is used to resolve the location of the devices file.
+    /// </param>
+    public DeviceRemoveCommand(IOptions<DeviceCollection> devices, IDirectoryResolver directoryResolver) {
         _devices = devices.Value;
+        _directoryResolver = directoryResolver;
     }
 
 
@@ -71,7 +80,7 @@ public class DeviceRemoveCommand : AsyncCommand<DeviceRemoveCommand.Settings> {
             Devices = _devices
         };
 
-        var devicesJsonFile = CommandUtilities.GetDevicesJsonFile();
+        var devicesJsonFile = _directoryResolver.GetDevicesDataFilePath();
 
         // Ensure directory exists.
         devicesJsonFile.Directory!.Create();

--- a/src/NRuuviTag.Cli/DirectoryResolverExtensions.cs
+++ b/src/NRuuviTag.Cli/DirectoryResolverExtensions.cs
@@ -1,0 +1,14 @@
+using System.IO;
+
+namespace NRuuviTag.Cli;
+
+public static class DirectoryResolverExtensions {
+    
+    extension(IDirectoryResolver resolver) {
+
+        public FileInfo GetLocalAppSettingsFilePath() => new FileInfo(Path.Combine(resolver.GetConfigDirectory(), "appsettings.nruuvitag.json"));
+        public FileInfo GetDevicesDataFilePath() => new FileInfo(Path.Combine(resolver.GetDataDirectory(), "devices.json"));
+
+    } 
+
+}

--- a/src/NRuuviTag.Cli/IDirectoryResolver.cs
+++ b/src/NRuuviTag.Cli/IDirectoryResolver.cs
@@ -1,0 +1,24 @@
+namespace NRuuviTag.Cli;
+
+/// <summary>
+/// <see cref="IDirectoryResolver"/> is used to resolve configuration and data directories used by the CLI tool.
+/// </summary>
+public interface IDirectoryResolver {
+
+    /// <summary>
+    /// Gets the directory containing user-specific app configuration files.
+    /// </summary>
+    /// <returns>
+    ///   The directory containing user-specific app configuration files.
+    /// </returns>
+    string GetConfigDirectory();
+    
+    /// <summary>
+    /// Gets the directory containing user-specific data files.
+    /// </summary>
+    /// <returns>
+    ///   The directory containing user-specific data files.
+    /// </returns>
+    string GetDataDirectory();
+
+}

--- a/src/NRuuviTag.Cli/NRuuviTagConfigurationBuilderExtensions.cs
+++ b/src/NRuuviTag.Cli/NRuuviTagConfigurationBuilderExtensions.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 
-using NRuuviTag.Cli.Commands;
+using NRuuviTag.Cli;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Configuration;
 
 /// <summary>
@@ -10,10 +11,13 @@ namespace Microsoft.Extensions.Configuration;
 public static class NRuuviTagConfigurationBuilderExtensions {
 
     /// <summary>
-    /// Adds known MQTT devices to the <see cref="IConfigurationBuilder"/>.
+    /// Adds local configuration and known Ruuvi devices to the <see cref="IConfigurationBuilder"/>.
     /// </summary>
     /// <param name="builder">
     ///   The <see cref="IConfigurationBuilder"/>.
+    /// </param>
+    /// <param name="directoryResolver">
+    ///   The <see cref="IDirectoryResolver"/> to resolve the local configuration files with.
     /// </param>
     /// <returns>
     ///   The <see cref="IConfigurationBuilder"/>.
@@ -21,10 +25,11 @@ public static class NRuuviTagConfigurationBuilderExtensions {
     /// <exception cref="ArgumentNullException">
     ///   <paramref name="builder"/> is <see langword="null"/>.
     /// </exception>
-    public static IConfigurationBuilder AddRuuviTagDeviceConfiguration(this IConfigurationBuilder builder) {
+    public static IConfigurationBuilder AddLocalConfiguration(this IConfigurationBuilder builder, IDirectoryResolver directoryResolver) {
         ArgumentNullException.ThrowIfNull(builder);
-
-        builder.AddJsonFile(CommandUtilities.GetDevicesJsonFile().FullName, optional: true, reloadOnChange: true);
+        ArgumentNullException.ThrowIfNull(directoryResolver);
+        builder.AddJsonFile(directoryResolver.GetLocalAppSettingsFilePath().FullName, optional: true, reloadOnChange: true);
+        builder.AddJsonFile(directoryResolver.GetDevicesDataFilePath().FullName, optional: true, reloadOnChange: true);
 
         return builder;
     }

--- a/src/NRuuviTag.Cli/NRuuviTagHostBuilder.cs
+++ b/src/NRuuviTag.Cli/NRuuviTagHostBuilder.cs
@@ -20,11 +20,15 @@ public static class NRuuviTagHostBuilder {
     /// <param name="args">
     ///   The command-line arguments.
     /// </param>
+    /// <param name="directoryResolver">
+    ///   The <see cref="IDirectoryResolver"/> that is used to resolve the location of the devices file.
+    /// </param>
     /// <returns>
     ///   A new <see cref="IHostBuilder"/> instance.
     /// </returns>
-    public static IHostBuilder CreateHostBuilder<TListenerFactory>(string[]? args) where TListenerFactory : class, IRuuviTagListenerFactory {
-        return CreateHostBuilderCore(args, (hostContext, services) => {
+    public static IHostBuilder CreateHostBuilder<TListenerFactory>(string[]? args, IDirectoryResolver directoryResolver) where TListenerFactory : class, IRuuviTagListenerFactory {
+        ArgumentNullException.ThrowIfNull(directoryResolver);
+        return CreateHostBuilderCore(args, directoryResolver, (hostContext, services) => {
             services.AddRuuviTagCommandApp<TListenerFactory>(hostContext.Configuration);
         });
     }
@@ -39,15 +43,19 @@ public static class NRuuviTagHostBuilder {
     /// <param name="args">
     ///   The command-line arguments.
     /// </param>
+    /// <param name="directoryResolver">
+    ///   The <see cref="IDirectoryResolver"/> that is used to resolve the location of the devices file.
+    /// </param>
     /// <param name="factory">
     ///   The listener instance to use.
     /// </param>
     /// <returns>
     ///   A new <see cref="IHostBuilder"/> instance.
     /// </returns>
-    public static IHostBuilder CreateHostBuilder<TListenerFactory>(string[]? args, TListenerFactory factory) where TListenerFactory : class, IRuuviTagListenerFactory {
+    public static IHostBuilder CreateHostBuilder<TListenerFactory>(string[]? args, IDirectoryResolver directoryResolver, TListenerFactory factory) where TListenerFactory : class, IRuuviTagListenerFactory {
+        ArgumentNullException.ThrowIfNull(directoryResolver);
         ArgumentNullException.ThrowIfNull(factory);
-        return CreateHostBuilder(args, _ => factory);
+        return CreateHostBuilder(args, directoryResolver, _ => factory);
     }
 
 
@@ -61,15 +69,19 @@ public static class NRuuviTagHostBuilder {
     /// <param name="args">
     ///   The command-line arguments.
     /// </param>
+    /// <param name="directoryResolver">
+    ///   The <see cref="IDirectoryResolver"/> that is used to resolve the location of the devices file.
+    /// </param>
     /// <param name="factory">
     ///   The listener factory to use.
     /// </param>
     /// <returns>
     ///   A new <see cref="IHostBuilder"/> instance.
     /// </returns>
-    public static IHostBuilder CreateHostBuilder<TListenerFactory>(string[]? args, Func<IServiceProvider, TListenerFactory> factory) where TListenerFactory : class, IRuuviTagListenerFactory {
+    public static IHostBuilder CreateHostBuilder<TListenerFactory>(string[]? args, IDirectoryResolver directoryResolver, Func<IServiceProvider, TListenerFactory> factory) where TListenerFactory : class, IRuuviTagListenerFactory {
+        ArgumentNullException.ThrowIfNull(directoryResolver);
         ArgumentNullException.ThrowIfNull(factory);
-        return CreateHostBuilderCore(args, (hostContext, services) => {
+        return CreateHostBuilderCore(args, directoryResolver, (hostContext, services) => {
             services.AddRuuviTagCommandApp(hostContext.Configuration, factory.Invoke);
         });
     }
@@ -78,13 +90,16 @@ public static class NRuuviTagHostBuilder {
     /// <summary>
     /// Configures core services for a host builder.
     /// </summary>
-    private static IHostBuilder CreateHostBuilderCore(string[]? args, Action<HostBuilderContext, IServiceCollection> configureServices) {
+    private static IHostBuilder CreateHostBuilderCore(string[]? args, IDirectoryResolver directoryResolver, Action<HostBuilderContext, IServiceCollection> configureServices) {
         return Host.CreateDefaultBuilder(args)
             .UseContentRoot(AppContext.BaseDirectory)
             .ConfigureAppConfiguration(config => {
-                config.AddRuuviTagDeviceConfiguration();
+                config.AddLocalConfiguration(directoryResolver);
             })
-            .ConfigureServices(configureServices);
+            .ConfigureServices((context, services) => {
+                configureServices.Invoke(context, services);
+                services.AddSingleton(directoryResolver);
+            });
     }
 
 }


### PR DESCRIPTION
Closes #80 by adding platform-specific data directory resolvers that use the correct standard locations for configuration and data files, and fall back to the legacy `~/.nruuvitag` folder if it already exists to maintain behaviour on existing installs.