### PR TITLE
Container bootstrapping script

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,43 +82,10 @@ The command-line application can be run on Linux as a container image.
 
 ### Happy Path
 
-You can copy and paste the following shell script to create an executable `nruuvitag` command on your host machine that bootstraps the container image for you:
+Download and run the [container bootstrap script](./scripts/bootstrap_container.sh) to create an executable `nruuvitag` command on your host machine in `~/.local/bin` that bootstraps the container image for you:
 
 ```sh
-local_bin="$HOME/.local/bin"
-exe_path="$local_bin/nruuvitag"
-
-mkdir -p "$local_bin"
-
-cat > "$exe_path" <<'EOF'
-#!/usr/bin/env bash
-
-# See GHCR for available image tags
-image="ghcr.io/wazzamatazz/nruuvitag:latest"
-
-# Run `nruuvitag update` to pull the latest container image
-if [[ $1 == "update" ]]; then
-  docker pull $image
-  exit 0
-fi
-
-# nruuvitag uses the XDG Base Directory Specification to determine where to 
-# store configuration files. If XDG_DATA_HOME is not set, ~/.local/share is
-# used by default.
-if [[ -z "$XDG_DATA_HOME" ]]; then
-    XDG_DATA_HOME="$HOME/.local/share"
-fi
-
-mkdir -p "$XDG_DATA_HOME/nruuvitag"
-
-docker run -it --rm \
-    -v /var/run/dbus:/var/run/dbus \
-    -v $XDG_DATA_HOME/nruuvitag:/root/.local/share/nruuvitag \
-    $image \
-    "$@"
-EOF
-
-chmod +x "$exe_path"
+curl -fsSL https://raw.githubusercontent.com/wazzamatazz/NRuuviTag/refs/heads/main/scripts/bootstrap_container.sh | bash
 ```
 
 You can then invoke the `nruuvitag` command as if it were installed locally on your host machine:
@@ -127,7 +94,7 @@ You can then invoke the `nruuvitag` command as if it were installed locally on y
 # List known devices
 nruuvitag devices list
 
-# Pull the latest container image (handled automatically by the script)
+# Pull the latest container image
 nruuvitag update
 ```
 

--- a/docs/release-notes/v6.0.md
+++ b/docs/release-notes/v6.0.md
@@ -1,0 +1,22 @@
+# NRuuviTag v6.0 Release Notes
+
+## Breaking Changes
+
+### Data File Location Change
+
+On Linux, the location of the CLI application's data files has changed from `~/.nruuvitag` to `~/.local/share/nruuvitag`. This change aligns with the XDG Base Directory Specification and ensures that data is stored in a more appropriate location for user-specific application data.
+
+On Windows, the location of the CLI application's data files has changed from `%USERPROFILE%\.nruuvitag` to `%LOCALAPPDATA%\NRuuviTag\data`. This change ensures that data is stored in a more appropriate location for user-specific application data.
+
+> [!TIP]
+> These changes affect new installs of the NRuuviTag CLI application only. Existing installations will continue to use the old data file if they already exist.
+
+### OpenTelemetry Configuration
+
+NRuuviTag no longer uses the Jaahas.OpenTelemetry.Extensions library for configuring OTLP export of logs and metrics. Standard OpenTelemetry environment variables are now used to configure the OTLP exporter. This change standardises the configuration process.
+
+See [here](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/) for more information about configuring OTLP export via environment variables.
+
+## Other Changes
+
+Creating an alias for running the CLI application in a container is no longer the recommended approach. Instead, a [shell script](../../scripts/bootstrap_container.sh) can be used to bootstrap an executable script in the XDG user-specific executable files directory that runs the container and maps the required volumes.

--- a/scripts/bootstrap_container.sh
+++ b/scripts/bootstrap_container.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+local_bin="$HOME/.local/bin"
+mkdir -p "$local_bin"
+
+tool_path="$local_bin/nruuvitag"
+cat > "$tool_path" <<'EOF'
+#!/usr/bin/env bash
+
+# See GHCR for available image tags
+image="ghcr.io/wazzamatazz/nruuvitag:latest"
+
+# Run `nruuvitag update` to pull the latest container image
+if [[ $1 == "update" ]]; then
+  docker pull $image
+  exit 0
+fi
+
+# nruuvitag uses the XDG Base Directory Specification to determine where to 
+# store data files. If XDG_DATA_HOME is not set, ~/.local/share is used by 
+# default.
+if [[ -z "$XDG_DATA_HOME" ]]; then
+    XDG_DATA_HOME="$HOME/.local/share"
+fi
+
+mkdir -p "$XDG_DATA_HOME/nruuvitag"
+
+docker run -it --rm \
+    -v /var/run/dbus:/var/run/dbus \
+    -v $XDG_DATA_HOME/nruuvitag:/root/.local/share/nruuvitag \
+    $image \
+    "$@"
+EOF
+
+chmod +x "$tool_path"


### PR DESCRIPTION
Adds a dedicated script for bootstrapping the container image to a local `nruuvitag` executable and adds release notes for v6 release.